### PR TITLE
fix: missing objectVersionField error 

### DIFF
--- a/wrapper/lib/zn-data.js
+++ b/wrapper/lib/zn-data.js
@@ -188,7 +188,7 @@ export function ZnData (plugin) {
           }
         }
 
-        const objectVersionField = options.objectVersionField
+        const objectVersionField = options && options.objectVersionField ? options.objectVersionField : false;  
 
         return request(path, { pathParams, objectVersionField }, method, params, data, success, error)
       }


### PR DESCRIPTION
add  check to avoid error when there is no objectVersionField parameter in the request