### PR TITLE
remove package-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 dist
 dist.zip
 node_modules
-package-lock.json
 plugin.json


### PR DESCRIPTION
When this is copied over to the migrated plugin you
want package-lock.json to be committed with the
plugin repo.