### PR TITLE
fix parameter object passed to plugin.client.call() method when performing a request with url parameters

### DIFF
--- a/wrapper/lib/zn-data.js
+++ b/wrapper/lib/zn-data.js
@@ -212,6 +212,36 @@ export function ZnData (plugin) {
       }
     }
 
+    function _flattenObject(ob) {
+      var toReturn = {};
+
+      for (var i in ob) {
+
+        if (!ob.hasOwnProperty(i)) {
+          continue;
+        }
+
+        if ((typeof ob[i]) == 'object') {
+          if (ob[i] instanceof Array) {
+            toReturn[i] = ob[i].join(',');
+          } else {
+            var flatObject = _flattenObject(ob[i]);
+            for (var x in flatObject) {
+
+              if (!flatObject.hasOwnProperty(x)) {
+                continue;
+              }
+
+              toReturn[i + '.' + x] = flatObject[x];
+            }
+          }
+        } else {
+          toReturn[i] = ob[i];
+        }
+      }
+      return toReturn;
+    }
+
     function request (path, options, method, params, data, successCb, errorCb) {
       const { pathParams, objectVersionField } = options
 
@@ -252,6 +282,9 @@ export function ZnData (plugin) {
         delete params[objectVersionField]
       }
       var deferred = $q.defer()
+
+      //flatten param object as is done in the original implementation of znData in anglerfish
+      params = _flattenObject(params);
 
       const call = () => {
         plugin.client.call({

--- a/wrapper/lib/zn-data.js
+++ b/wrapper/lib/zn-data.js
@@ -213,33 +213,33 @@ export function ZnData (plugin) {
     }
 
     function _flattenObject(ob) {
-      var toReturn = {};
+      const toReturn = {}
 
-      for (var i in ob) {
+      for (let i in ob) {
 
-        if (!ob.hasOwnProperty(i)) {
-          continue;
+        if (!ob[i]) {
+          continue
         }
 
         if ((typeof ob[i]) == 'object') {
           if (ob[i] instanceof Array) {
-            toReturn[i] = ob[i].join(',');
+            toReturn[i] = ob[i].join(',')
           } else {
-            var flatObject = _flattenObject(ob[i]);
-            for (var x in flatObject) {
+            let flatObject = _flattenObject(ob[i])
+            for (let x in flatObject) {
 
-              if (!flatObject.hasOwnProperty(x)) {
-                continue;
+              if (!flatObject[x]) {
+                continue
               }
 
-              toReturn[i + '.' + x] = flatObject[x];
+              toReturn[i + '.' + x] = flatObject[x]
             }
           }
         } else {
-          toReturn[i] = ob[i];
+          toReturn[i] = ob[i]
         }
       }
-      return toReturn;
+      return toReturn
     }
 
     function request (path, options, method, params, data, successCb, errorCb) {


### PR DESCRIPTION
having a javascript object representing  API query parameters like this: 

```json
{
 "attributes": "id,name,singularName,settings.newRecordFolderId",
 "limit":500,
 "related": "fields,folders",
 "workspace":{"id":1234}
}
```

needs to be converted to 

```json
{
 "attributes": "id,name,singularName,settings.newRecordFolderId",
 "limit":500,
 "related": "fields,folders",
 "workspace.id":1234
}
```

previous to make the request

the code for _flattenObject function was taken from the original implementation of Data service in anglerfish. You can check that code here:

https://github.com/Wizehive/anglerfish/blob/334347269358a3e94fb7ba27b1aa1bd6b529f51c/app/js/core/resources.js#L137

which is called on every request done with the original znData through the beforeFilter function call here

https://github.com/Wizehive/anglerfish/blob/334347269358a3e94fb7ba27b1aa1bd6b529f51c/app/js/core/resources.js#L301