### PR TITLE
better selector for gray background

### DIFF
--- a/wrapper/plugin.scss
+++ b/wrapper/plugin.scss
@@ -1,5 +1,3 @@
-@import 'tinymce/skins/lightgray/content.min.css';
-@import 'tinymce/skins/lightgray/skin.min.css';
 @import 'ng-grid/ng-grid.min.css';
 @import 'ui-select/dist/select.min.css';
 @import './css/bootstrap.css';
@@ -83,9 +81,8 @@ body {
 	color:#fff;
 }
 
-.mce-panel {
-	border: 0 solid #c5c5c5;
-	background-color: #f0f0f0 !important;
+.mce-statusbar {
+  background-color: #f0f0f0 !important;
 }
 
 .mce-btn {


### PR DESCRIPTION
If you look at the dropdowns, there is an awkward gray background peeking at top and bottom.
![Screen Shot 2020-01-08 at 16 13 56](https://user-images.githubusercontent.com/26337310/72016498-e2518100-3231-11ea-8f31-8d2c09799ec1.png)

this PR puts the gray background on a better selector, so the dropdowns are pure white like the og tinymce.

![Screen Shot 2020-01-08 at 16 15 24](https://user-images.githubusercontent.com/26337310/72016599-15941000-3232-11ea-9cf8-fba9cfd34dd0.png)

