### PR TITLE
fix: hrefs should open in the parent frame

### DIFF
--- a/wrapper/lib/directives.js
+++ b/wrapper/lib/directives.js
@@ -2041,7 +2041,49 @@ export function Directives (plugin) {
           });
         }
       };
-    }])
+    }]);
+
+    function href($location) {
+      return {
+        restrict: 'A',
+        scope: {
+          relative: '='
+        },
+        link: function (scope, element, attrs) {
+          element.bind('click', e => {
+
+            const platformUrl = $location.protocol() + '://' + $location.host();
+            let url = attrs.href;
+            const withinPlatform = url.indexOf(platformUrl) === 0;
+
+            // open external links in new tab
+            if (url.match(/^https?|www|mailto|\/\//) &&
+              (url.indexOf(platformUrl) === -1 || attrs.target === '_blank')) {
+              e.preventDefault();
+              return window.open(url, attrs.target || '_top');
+            } else if (url.match(/^\/|\?|#/) || withinPlatform || scope.relative) {
+              e.preventDefault();
+              if (withinPlatform) {
+                url = url.replace(platformUrl, '');
+              }
+
+              if (scope.relative) {
+                if (url.indexOf('/' !== 0)) {
+                  url = '/' + url;
+                }
+                url = $location.path() + url
+              }
+
+              $location.url(url);
+
+            }
+
+          });
+        }
+      };
+    }
+    plugin.directive('href', ['$location', href])
+    .directive('ngHref', ['$location', href])
     .directive('znTooltip', [function () {
       return {
         restrict: 'A',


### PR DESCRIPTION
``` html    
<h2>Links</h2>
    <br/>
    <a href="unicorns/123" relative="true">Internal Plugin Route!</a>
    <br/>
    <a href="#">Anchor - #</a>
    <br/>
    <a href="#test">Anchor - #test</a>
    <br/>
    <a href="/workspaces/{{workspaceId}}/data/{{formId}}?record={{formId}}.1&tab=events">Path + Query - /workspaces/{{workspaceId}}/data/{{formId}}?record={{formId}}.1&tab=events</a>
    <br/>
    <a href="javascript:void(0)">Void do nothing</a>
    <br/>
    <a ng-href="?record={{formId}}.1&tab=events#test">Query Params - ?record={{formId}}.1&tab=events#test</a>
    <br/>
    <a ng-href="/workspaces/{{workspaceId}}/admin/forms/{{formId}}">Internal App Link - /workspaces/{{workspaceId}}/admin/forms/{{formId}}</a>
    <br/>
    <a href="https://platform.wizehive-dev.com/workspaces/1/plugin/modal-playground/unicorns">Full Plugin Url</a>
    <br/>
    <a href="https://platform.wizehive-dev.com/workspaces/1/plugin/modal-playground/unicorns" target="_top">Full Plugin Url Top Target</a>
    <br/>
    <a href="https://platform.wizehive-dev.com/workspaces/1/plugin/modal-playground/unicorns" target="_blank">Full Plugin Url New Tab</a>

    <br/>
    <a href="mailto:anna@wizehive.com?Subject=Hello%20again" target="_blank">Send Mail New Target</a>
    <br/>
    <a href="mailto:anna@wizehive.com?Subject=Hello%20again">Send Mail No Target</a>
    <br/>
    <a href="https://google.com" target="_blank">Https External Link New Tab</a>
    <br/>
    <a href="https://google.com">Https External Link (No Target)</a>
    <br/>
    <a href="http://google.com">Http External Link (No Target)</a>
    <br/>
    <a href="//google.com">Double Slash External Link</a>
    <br/>
    <a href="ftp://ftp.adobe.com/">FTP Link - ftp://ftp.adobe.com</a>
    <br/>
    <a href="tel:+123456789">Telephone </a>
    <br/>