### PR TITLE
fix linting error

### DIFF
--- a/wrapper/lib/directives.js
+++ b/wrapper/lib/directives.js
@@ -2043,7 +2043,7 @@ export function Directives (plugin) {
       };
     }]);
 
-  function href($location) {
+  function href ($location) {
     return {
       restrict: 'A',
       scope: {


### PR DESCRIPTION
this little whitespace  is triggering a linter error when running

``` npm run lint-wrapper```