### PR TITLE
fix: ie tinymce

### DIFF
--- a/wrapper/lib/wrapper.js
+++ b/wrapper/lib/wrapper.js
@@ -207,6 +207,9 @@ async function compileProviderIsReady () {
     'firebase',
     'LocalStorageModule'
   ])
+    .value('uiTinymceConfig', {
+      baseUrl: location.origin
+    })
     .config(['$compileProvider', function ($compileProvider) {
       plugin.compileProvider = $compileProvider;
     }])


### PR DESCRIPTION
tinymce code uses document.currentScript to figure out baseURL, but
document.currentScript is unsupported in IE11

https://stackoverflow.com/questions/37163463/tiny-mce-editor-with-angular-js-not-working-on-ie

set baseURL manually in config