### PR TITLE
chore: use ui-sortable version from wizehive repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "angular-local-storage": "0.1.4",
     "angular-sanitize": "1.2.27",
     "angular-ui-ace": "github:Wizehive/ui-ace",
-    "angular-ui-sortable": "0.13.4",
+    "angular-ui-sortable": "github:Wizehive/ui-sortable",
     "angular-ui-tinymce": "github:Wizehive/ui-tinymce",
     "angularfire": "github:Wizehive/angularFire#v0.8.0",
     "bignumber.js": "github:Wizehive/bignumber.js#v2.4.0",


### PR DESCRIPTION
review portal doesn't work with version 0.13.4 but it does with 0.13.1 which is the one used by anglerfish and is on this repo owned by wizehive

https://github.com/Wizehive/ui-sortable